### PR TITLE
Fix image display and improve dataset handling

### DIFF
--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -845,7 +845,7 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 for img in res.get('images', []):
                     # Images are served through the /file endpoint. Prefix paths
                     # so that the markdown renderer can display them correctly.
-                    final_text += f"\n![image](file/{img})"
+                    final_text += f"\n![image](/file/{img})"
         except Exception as e:
             logger.error(f"Python tool execution error: {e}")
     output['internal'][-1][1] = final_text

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -846,10 +846,10 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 for img in res.get('images', []):
                     # Link images through the file endpoint to avoid embedding
                     # large base64 blobs directly in the chat. The Gradio UI
-                    # expects a relative path starting with 'file/'.
+                    # expects paths to begin with '/file/'.
                     try:
                         rel = quote(Path(img).as_posix())
-                        final_text += f"\n![image](file/{rel})"
+                        final_text += f"\n![image](/file/{rel})"
                     except Exception:
                         final_text += f"\n[Image saved to {img}]"
         except Exception as e:

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -844,12 +844,12 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 if res.get('stdout'):
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
-                    # Link images through the file endpoint to avoid embedding
-                    # large base64 blobs directly in the chat. The Gradio UI
-                    # expects paths to begin with '/file/'.
+                    # Ссылаемся на сгенерированное изображение через эндпоинт
+                    # "file". Путь должен быть относительным и начинаться с
+                    # "file/", иначе интерфейс не сможет отобразить картинку.
                     try:
                         rel = quote(Path(img).as_posix())
-                        final_text += f"\n![image](/file/{rel})"
+                        final_text += f"\n![image](file/{rel})"
                     except Exception:
                         final_text += f"\n[Image saved to {img}]"
         except Exception as e:

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -843,9 +843,14 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 if res.get('stdout'):
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
-                    # Images are served through the /file endpoint. Prefix paths
-                    # so that the markdown renderer can display them correctly.
-                    final_text += f"\n![image](/file/{img})"
+                    # Inline images directly in the message using base64. The
+                    # interface reliably displays embedded data URIs even when
+                    # static file serving is unavailable.
+                    try:
+                        b64 = base64.b64encode(Path(img).read_bytes()).decode('ascii')
+                        final_text += f"\n![image](data:image/png;base64,{b64})"
+                    except Exception:
+                        final_text += f"\n[Image saved to {img}]"
         except Exception as e:
             logger.error(f"Python tool execution error: {e}")
     output['internal'][-1][1] = final_text

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 import shutil
+from urllib.parse import quote
 
 import gradio as gr
 import yaml
@@ -843,10 +844,12 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 if res.get('stdout'):
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
-                    # Link images through the /file endpoint to avoid
-                    # embedding large base64 blobs directly in the chat.
+                    # Link images through the file endpoint to avoid embedding
+                    # large base64 blobs directly in the chat. The Gradio UI
+                    # expects a relative path starting with 'file/'.
                     try:
-                        final_text += f"\n![image](/file/{Path(img).as_posix()})"
+                        rel = quote(Path(img).as_posix())
+                        final_text += f"\n![image](file/{rel})"
                     except Exception:
                         final_text += f"\n[Image saved to {img}]"
         except Exception as e:

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -845,11 +845,11 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
                     # Ссылаемся на сгенерированное изображение через эндпоинт
-                    # "file". Путь должен быть относительным и начинаться с
-                    # "file/", иначе интерфейс не сможет отобразить картинку.
+                    # "/file". Для корректной загрузки слэши не должны быть
+                    # URL-кодированы, поэтому передаём safe="/".
                     try:
-                        rel = quote(Path(img).as_posix())
-                        final_text += f"\n![image](file/{rel})"
+                        rel = quote(Path(img).as_posix(), safe="/")
+                        final_text += f"\n![image](/file/{rel})"
                     except Exception:
                         final_text += f"\n[Image saved to {img}]"
         except Exception as e:

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -843,7 +843,9 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 if res.get('stdout'):
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
-                    final_text += f"\n![image]({img})"
+                    # Images are served through the /file endpoint. Prefix paths
+                    # so that the markdown renderer can display them correctly.
+                    final_text += f"\n![image](file/{img})"
         except Exception as e:
             logger.error(f"Python tool execution error: {e}")
     output['internal'][-1][1] = final_text

--- a/text-generation-webui-3.8/modules/chat.py
+++ b/text-generation-webui-3.8/modules/chat.py
@@ -843,12 +843,10 @@ def chatbot_wrapper(text, state, regenerate=False, _continue=False, loading_mess
                 if res.get('stdout'):
                     final_text += f"\n```\n{res['stdout']}\n```"
                 for img in res.get('images', []):
-                    # Inline images directly in the message using base64. The
-                    # interface reliably displays embedded data URIs even when
-                    # static file serving is unavailable.
+                    # Link images through the /file endpoint to avoid
+                    # embedding large base64 blobs directly in the chat.
                     try:
-                        b64 = base64.b64encode(Path(img).read_bytes()).decode('ascii')
-                        final_text += f"\n![image](data:image/png;base64,{b64})"
+                        final_text += f"\n![image](/file/{Path(img).as_posix()})"
                     except Exception:
                         final_text += f"\n[Image saved to {img}]"
         except Exception as e:

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -58,6 +58,8 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
     if pd is None:
         return '[pandas not installed]'
     path = Path(file_path)
+    # Register the table so ``get_table_path`` can resolve it later
+    register_table(path)
     parts = [f"Table: {path.name}"]
     suffix = path.suffix.lower()
 
@@ -80,11 +82,16 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
         else:
             uniques = {}
         if df is None:
-            df = pd.read_csv(path, nrows=max_rows, dtype=str)
+            df = pd.read_csv(path, nrows=max_rows, low_memory=False)
+            types = df.dtypes.astype(str).to_dict()
+            df = df.astype(str)
             try:
                 uniques = _count_uniques_csv(path, df.columns)
             except Exception:
                 uniques = {}
+        else:
+            types = df.dtypes.astype(str).to_dict()
+            df = df.astype(str)
         try:
             with open(path, 'r', encoding='utf-8', errors='ignore') as fh:
                 row_count = sum(1 for _ in fh) - 1
@@ -93,6 +100,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
         df = _truncate_frame(df, cell_limit)
         columns = ', '.join(str(c) for c in df.columns)
         parts.append(f"Columns: {columns}")
+        parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
         parts.append(df.to_csv(index=False))
         if row_count is not None:
             parts.append(f"Rows: {row_count}")
@@ -101,8 +109,9 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                 "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
             )
         parts.append(
-            f"Use get_table_path('{path.name}') to load this table in Python. "
-            "Enclose analysis in ```python``` blocks to execute it. "
+            f"Use get_table_path('{path.name}') to load the full table in Python. "
+            "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
+            "Enclose analysis in ```python``` blocks. "
             f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
         )
         return "\n".join(parts)
@@ -136,6 +145,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                     uniques = full_pd.nunique(dropna=False).to_dict()
                 except Exception:
                     uniques = {}
+            types = pdf.dtypes.astype(str).to_dict()
             pdf = _truncate_frame(pdf, cell_limit)
             columns = ', '.join(str(c) for c in pdf.columns)
             if row_count is not None:
@@ -143,14 +153,16 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
             else:
                 parts.append(f"Sheet: {sheet}")
             parts.append(f"Columns: {columns}")
+            parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
             parts.append(pdf.to_csv(index=False))
             if uniques:
                 parts.append(
                     "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
         parts.append(
-            f"Use get_table_path('{path.name}') to load this table in Python. "
-            "Enclose analysis in ```python``` blocks to execute it. "
+            f"Use get_table_path('{path.name}') to load the full table in Python. "
+            "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
+            "Enclose analysis in ```python``` blocks. "
             f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
         )
         return "\n".join(parts)
@@ -191,9 +203,11 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                     uniques = pd.read_parquet(path).nunique(dropna=False).to_dict()
                 except Exception:
                     uniques = {}
+            types = df.dtypes.astype(str).to_dict()
             df = _truncate_frame(df, cell_limit)
             columns = ', '.join(str(c) for c in df.columns)
             parts.append(f"Columns: {columns}")
+            parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
             parts.append(df.to_csv(index=False))
             if row_count is not None:
                 parts.append(f"Rows: {row_count}")
@@ -202,8 +216,9 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                     "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
             parts.append(
-                f"Use get_table_path('{path.name}') to load this table in Python. "
-                "Enclose analysis in ```python``` blocks to execute it. "
+                f"Use get_table_path('{path.name}') to load the full table in Python. "
+                "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
+                "Enclose analysis in ```python``` blocks. "
                 f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
             )
             return "\n".join(parts)
@@ -222,8 +237,9 @@ def answer_question_with_pandas(question: str, file_path: str | Path) -> str:
     prompt = (
         f"Table `{table_name}` preview:\n{summary}\n\n"
         f"Question: {question}\n"
-        "Write pandas code to answer the question. "
-        "Store the answer in the variable `result`."
+        "Write pandas code to answer the question using the full table. "
+        "Inspect df.dtypes and cast columns (e.g. pd.to_datetime) before filtering. "
+        "Store the answer in the variable `result` and reply in the same language as the question."
     )
     return prompt
 

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -51,7 +51,7 @@ def _preload_table(path: Path) -> None:
 
 def register_table(file_path: str | Path) -> str:
     """Register a table path and return its name identifier."""
-    path = Path(file_path)
+    path = Path(file_path).resolve()
     name = path.name
     _loaded_tables[name] = str(path)
     return name

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -62,6 +62,24 @@ def get_table_path(name: str) -> str | None:
     return _loaded_tables.get(name)
 
 
+def load_table(name: str):
+    """Return a cached table by name, loading it from disk if necessary.
+
+    For Excel files, returns a dict mapping sheet names to DataFrames.
+    Raises FileNotFoundError if the table name is unknown or cannot be
+    loaded.
+    """
+    path_str = get_table_path(name)
+    if not path_str:
+        raise FileNotFoundError(f"Неизвестная таблица: {name}")
+    path = Path(path_str)
+    if name not in _table_cache:
+        _preload_table(path)
+    if name in _table_cache:
+        return _table_cache[name]
+    raise FileNotFoundError(f"Не удалось загрузить таблицу: {name}")
+
+
 def _truncate_frame(df: "pd.DataFrame", limit: int) -> "pd.DataFrame":
     """Return a copy of ``df`` with each cell truncated to ``limit`` characters."""
     if limit:
@@ -145,7 +163,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                 "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
             )
         parts.append(
-            f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+            f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
             "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
             "Заключайте анализ в блоки ```python```. "
             f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
@@ -197,7 +215,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                     "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
         parts.append(
-            f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+            f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
             "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
             "Заключайте анализ в блоки ```python```. "
             f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
@@ -254,7 +272,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                     "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
             parts.append(
-                f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+                f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
                 "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
                 "Заключайте анализ в блоки ```python```. "
                 f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
@@ -277,6 +295,7 @@ def answer_question_with_pandas(question: str, file_path: str | Path) -> str:
         f"Предпросмотр таблицы `{table_name}`:\n{summary}\n\n"
         f"Вопрос: {question}\n"
         "Напишите код на pandas, чтобы ответить на вопрос, используя всю таблицу. "
+        f"Получите DataFrame через load_table('{table_name}'). "
         "Перед фильтрацией посмотрите df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime). "
         "Сохраните ответ в переменную `result` и отвечайте на том же языке, что и вопрос."
     )

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -16,6 +16,39 @@ _loaded_tables: dict[str, str] = {}
 _table_cache: dict[str, "pd.DataFrame"] = {}
 
 
+def _preload_table(path: Path) -> None:
+    """Load the entire table into cache so pandas queries use full data."""
+    name = path.name
+    if name in _table_cache:
+        return
+    try:
+        suffix = path.suffix.lower()
+        if suffix == '.csv':
+            if pl:
+                _table_cache[name] = pl.read_csv(path).to_pandas()
+            else:
+                _table_cache[name] = pd.read_csv(path, low_memory=False)
+        elif suffix in {'.xls', '.xlsx'}:
+            xls = pd.ExcelFile(path)
+            sheets = {}
+            for sheet in xls.sheet_names:
+                if pl:
+                    try:
+                        sheets[sheet] = pl.read_excel(path, sheet_name=sheet).to_pandas()
+                    except Exception:
+                        sheets[sheet] = xls.parse(sheet)
+                else:
+                    sheets[sheet] = xls.parse(sheet)
+            _table_cache[name] = sheets
+        elif suffix == '.parquet':
+            if pl:
+                _table_cache[name] = pl.read_parquet(path).to_pandas()
+            else:
+                _table_cache[name] = pd.read_parquet(path)
+    except Exception:
+        pass
+
+
 def register_table(file_path: str | Path) -> str:
     """Register a table path and return its name identifier."""
     path = Path(file_path)
@@ -59,11 +92,11 @@ def _count_uniques_csv(path: Path, columns) -> dict[str, int]:
 def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> str:
     """Return a lightweight textual preview of an Excel, CSV or Parquet table."""
     if pd is None:
-        return '[pandas not installed]'
+        return '[pandas не установлен]'
     path = Path(file_path)
     # Register the table so ``get_table_path`` can resolve it later
     register_table(path)
-    parts = [f"Table: {path.name}"]
+    parts = [f"Таблица: {path.name}"]
     suffix = path.suffix.lower()
 
     if suffix == '.csv':
@@ -71,7 +104,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
         df = None
         if pl:
             try:
-                scan = pl.scan_csv(path, ignore_errors=True)
+                scan = pl.scan_csv(path)
                 df = scan.head(max_rows).collect().to_pandas()
                 uniq_df = (
                     scan.select([pl.col(c).n_unique().alias(str(c)) for c in df.columns])
@@ -102,21 +135,22 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
             row_count = None
         df = _truncate_frame(df, cell_limit)
         columns = ', '.join(str(c) for c in df.columns)
-        parts.append(f"Columns: {columns}")
-        parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
+        parts.append(f"Столбцы: {columns}")
+        parts.append("Типы: " + ", ".join(f"{k}={v}" for k, v in types.items()))
         parts.append(df.to_csv(index=False))
         if row_count is not None:
-            parts.append(f"Rows: {row_count}")
+            parts.append(f"Строки: {row_count}")
         if uniques:
             parts.append(
-                "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
+                "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
             )
         parts.append(
-            f"Use get_table_path('{path.name}') to load the full table in Python. "
-            "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
-            "Enclose analysis in ```python``` blocks. "
-            f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
+            f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+            "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
+            "Заключайте анализ в блоки ```python```. "
+            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
         )
+        _preload_table(path)
         return "\n".join(parts)
 
     if suffix in {'.xls', '.xlsx'}:
@@ -152,22 +186,23 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
             pdf = _truncate_frame(pdf, cell_limit)
             columns = ', '.join(str(c) for c in pdf.columns)
             if row_count is not None:
-                parts.append(f"Sheet: {sheet} ({row_count} rows)")
+                parts.append(f"Лист: {sheet} ({row_count} строк)")
             else:
-                parts.append(f"Sheet: {sheet}")
-            parts.append(f"Columns: {columns}")
-            parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
+                parts.append(f"Лист: {sheet}")
+            parts.append(f"Столбцы: {columns}")
+            parts.append("Типы: " + ", ".join(f"{k}={v}" for k, v in types.items()))
             parts.append(pdf.to_csv(index=False))
             if uniques:
                 parts.append(
-                    "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
+                    "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
         parts.append(
-            f"Use get_table_path('{path.name}') to load the full table in Python. "
-            "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
-            "Enclose analysis in ```python``` blocks. "
-            f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
+            f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+            "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
+            "Заключайте анализ в блоки ```python```. "
+            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
         )
+        _preload_table(path)
         return "\n".join(parts)
 
     if suffix == '.parquet':
@@ -209,40 +244,41 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
             types = df.dtypes.astype(str).to_dict()
             df = _truncate_frame(df, cell_limit)
             columns = ', '.join(str(c) for c in df.columns)
-            parts.append(f"Columns: {columns}")
-            parts.append("Dtypes: " + ", ".join(f"{k}={v}" for k, v in types.items()))
+            parts.append(f"Столбцы: {columns}")
+            parts.append("Типы: " + ", ".join(f"{k}={v}" for k, v in types.items()))
             parts.append(df.to_csv(index=False))
             if row_count is not None:
-                parts.append(f"Rows: {row_count}")
+                parts.append(f"Строки: {row_count}")
             if uniques:
                 parts.append(
-                    "Unique values: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
+                    "Уникальные значения: " + ", ".join(f"{k}={v}" for k, v in uniques.items())
                 )
             parts.append(
-                f"Use get_table_path('{path.name}') to load the full table in Python. "
-                "Always inspect df.dtypes and convert columns (e.g. with pd.to_datetime) before filtering. "
-                "Enclose analysis in ```python``` blocks. "
-                f"Preview limited to {max_rows} rows and {cell_limit} chars per cell."
+                f"Используйте get_table_path('{path.name}') для загрузки полной таблицы в Python. "
+                "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
+                "Заключайте анализ в блоки ```python```. "
+                f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
             )
+            _preload_table(path)
             return "\n".join(parts)
         except Exception as e:
-            return f"[Error reading parquet: {e}]"
+            return f"[Ошибка чтения parquet: {e}]"
 
-    raise ValueError('Unsupported file type: %s' % path.suffix)
+    raise ValueError('Неподдерживаемый тип файла: %s' % path.suffix)
 
 
 def answer_question_with_pandas(question: str, file_path: str | Path) -> str:
     """Return a prompt for an LLM to generate pandas code."""
     if pd is None:
-        raise RuntimeError('pandas is required for table questions')
+        raise RuntimeError('Для работы с таблицами требуется pandas')
     table_name = register_table(file_path)
     summary = summarize_table(file_path)
     prompt = (
-        f"Table `{table_name}` preview:\n{summary}\n\n"
-        f"Question: {question}\n"
-        "Write pandas code to answer the question using the full table. "
-        "Inspect df.dtypes and cast columns (e.g. pd.to_datetime) before filtering. "
-        "Store the answer in the variable `result` and reply in the same language as the question."
+        f"Предпросмотр таблицы `{table_name}`:\n{summary}\n\n"
+        f"Вопрос: {question}\n"
+        "Напишите код на pandas, чтобы ответить на вопрос, используя всю таблицу. "
+        "Перед фильтрацией посмотрите df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime). "
+        "Сохраните ответ в переменную `result` и отвечайте на том же языке, что и вопрос."
     )
     return prompt
 
@@ -250,21 +286,21 @@ def answer_question_with_pandas(question: str, file_path: str | Path) -> str:
 def execute_pandas_code(
     code: str,
     file_path: str | Path | None,
-    max_output_rows: int | None = 20,
+    max_output_rows: int | None = 100,
     cell_limit: int = 80,
 ) -> str:
     """Execute pandas code against the provided table and return the result."""
     if pd is None:
-        return 'pandas is required'
+        return 'требуется pandas'
     if not file_path:
-        return 'No file path provided'
+        return 'Не указан путь к файлу'
     path = Path(file_path)
     if not path.exists():
         alt = get_table_path(path.name)
         if alt:
             path = Path(alt)
         else:
-            return f'File not found: {path}'
+            return f'Файл не найден: {path}'
     suffix = path.suffix.lower()
     local_vars = {}
     name = path.name
@@ -276,7 +312,7 @@ def execute_pandas_code(
             else:
                 if pl:
                     try:
-                        df = pl.scan_csv(path, ignore_errors=True).collect().to_pandas()
+                        df = pl.scan_csv(path).collect().to_pandas()
                     except Exception:
                         df = pd.read_csv(path, low_memory=False)
                 else:
@@ -312,11 +348,11 @@ def execute_pandas_code(
                     else:
                         df = pd.read_parquet(path)
                 except Exception as e:
-                    return f'Error reading parquet: {e}'
+                    return f'Ошибка чтения parquet: {e}'
                 _table_cache[name] = df
                 local_vars['df'] = df
         else:
-            return f'Unsupported file type: {path.suffix}'
+            return f'Неподдерживаемый тип файла: {path.suffix}'
 
         exec(code, {'pd': pd}, local_vars)
         result = local_vars.get('result')
@@ -327,14 +363,14 @@ def execute_pandas_code(
                 )
                 return f"{head}\n... ({len(result) - max_output_rows} more rows)"
             return _truncate_frame(result, cell_limit).to_csv(index=False)
-        return str(result) if result is not None else 'No result'
+        return str(result) if result is not None else 'Нет результата'
     except Exception as e:
-        return f'Error executing code: {e}'
+        return f'Ошибка выполнения кода: {e}'
 
 
 def execute_pandas_code_by_name(code: str, table_name: str) -> str:
     """Execute code using a previously registered table name."""
     path = get_table_path(table_name)
     if not path:
-        return f'Unknown table: {table_name}'
+        return f'Неизвестная таблица: {table_name}'
     return execute_pandas_code(code, path)

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -31,11 +31,26 @@ def _truncate_frame(df: "pd.DataFrame", limit: int) -> "pd.DataFrame":
     if limit:
         df_str = df.astype(str)
         truncate = lambda x: x[:limit] + ("..." if len(x) > limit else "")
-        # DataFrame.map was introduced in pandas 2.1 as a replacement for applymap
+        # pandas <2.1 does not expose DataFrame.map and using applymap
+        # raises a FutureWarning in newer versions. Use column-wise map to
+        # remain compatible across pandas releases without emitting warnings.
         if hasattr(df_str, "map"):
             return df_str.map(truncate)
-        return df_str.applymap(truncate)
+        return df_str.apply(lambda col: col.map(truncate))
     return df
+
+
+def _count_uniques_csv(path: Path, columns) -> dict[str, int]:
+    """Return the number of unique values for each column in a CSV file.
+
+    The CSV is processed in chunks to avoid loading the entire file into
+    memory at once, enabling handling of very large files.
+    """
+    uniques_sets: dict[str, set] = {c: set() for c in columns}
+    for chunk in pd.read_csv(path, dtype=str, usecols=columns, chunksize=10000):
+        for col in columns:
+            uniques_sets[col].update(chunk[col].dropna().astype(str).unique())
+    return {col: len(vals) for col, vals in uniques_sets.items()}
 
 
 def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> str:
@@ -67,11 +82,7 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
         if df is None:
             df = pd.read_csv(path, nrows=max_rows, dtype=str)
             try:
-                uniques = (
-                    pd.read_csv(path, dtype=str, usecols=df.columns)
-                    .nunique(dropna=False)
-                    .to_dict()
-                )
+                uniques = _count_uniques_csv(path, df.columns)
             except Exception:
                 uniques = {}
         try:
@@ -230,7 +241,11 @@ def execute_pandas_code(
         return 'No file path provided'
     path = Path(file_path)
     if not path.exists():
-        return f'File not found: {path}'
+        alt = get_table_path(path.name)
+        if alt:
+            path = Path(alt)
+        else:
+            return f'File not found: {path}'
     suffix = path.suffix.lower()
     local_vars = {}
 
@@ -240,9 +255,9 @@ def execute_pandas_code(
                 try:
                     local_vars['df'] = pl.scan_csv(path, ignore_errors=True).collect().to_pandas()
                 except Exception:
-                    local_vars['df'] = pd.read_csv(path)
+                    local_vars['df'] = pd.read_csv(path, low_memory=False)
             else:
-                local_vars['df'] = pd.read_csv(path)
+                local_vars['df'] = pd.read_csv(path, low_memory=False)
         elif suffix in {'.xls', '.xlsx'}:
             xls = pd.ExcelFile(path)
             for sheet in xls.sheet_names:

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -11,6 +11,9 @@ except Exception:  # pragma: no cover - optional dependency
     pl = None
 
 _loaded_tables: dict[str, str] = {}
+# Cache loaded DataFrames so subsequent queries do not reread large
+# datasets from disk. Keys are the registered table names.
+_table_cache: dict[str, "pd.DataFrame"] = {}
 
 
 def register_table(file_path: str | Path) -> str:
@@ -264,37 +267,54 @@ def execute_pandas_code(
             return f'File not found: {path}'
     suffix = path.suffix.lower()
     local_vars = {}
+    name = path.name
 
     try:
         if suffix == '.csv':
-            if pl:
-                try:
-                    local_vars['df'] = pl.scan_csv(path, ignore_errors=True).collect().to_pandas()
-                except Exception:
-                    local_vars['df'] = pd.read_csv(path, low_memory=False)
+            if name in _table_cache:
+                local_vars['df'] = _table_cache[name]
             else:
-                local_vars['df'] = pd.read_csv(path, low_memory=False)
+                if pl:
+                    try:
+                        df = pl.scan_csv(path, ignore_errors=True).collect().to_pandas()
+                    except Exception:
+                        df = pd.read_csv(path, low_memory=False)
+                else:
+                    df = pd.read_csv(path, low_memory=False)
+                _table_cache[name] = df
+                local_vars['df'] = df
         elif suffix in {'.xls', '.xlsx'}:
-            xls = pd.ExcelFile(path)
-            for sheet in xls.sheet_names:
-                if pl:
-                    try:
-                        local_vars[sheet] = pl.read_excel(path, sheet_name=sheet).to_pandas()
-                    except Exception:
-                        local_vars[sheet] = xls.parse(sheet)
-                else:
-                    local_vars[sheet] = xls.parse(sheet)
+            if name in _table_cache:
+                sheets = _table_cache[name]
+            else:
+                xls = pd.ExcelFile(path)
+                sheets = {}
+                for sheet in xls.sheet_names:
+                    if pl:
+                        try:
+                            sheets[sheet] = pl.read_excel(path, sheet_name=sheet).to_pandas()
+                        except Exception:
+                            sheets[sheet] = xls.parse(sheet)
+                    else:
+                        sheets[sheet] = xls.parse(sheet)
+                _table_cache[name] = sheets
+            local_vars.update(sheets)
         elif suffix == '.parquet':
-            try:
-                if pl:
-                    try:
-                        local_vars['df'] = pl.scan_parquet(path).collect().to_pandas()
-                    except Exception:
-                        local_vars['df'] = pd.read_parquet(path)
-                else:
-                    local_vars['df'] = pd.read_parquet(path)
-            except Exception as e:
-                return f'Error reading parquet: {e}'
+            if name in _table_cache:
+                local_vars['df'] = _table_cache[name]
+            else:
+                try:
+                    if pl:
+                        try:
+                            df = pl.scan_parquet(path).collect().to_pandas()
+                        except Exception:
+                            df = pd.read_parquet(path)
+                    else:
+                        df = pd.read_parquet(path)
+                except Exception as e:
+                    return f'Error reading parquet: {e}'
+                _table_cache[name] = df
+                local_vars['df'] = df
         else:
             return f'Unsupported file type: {path.suffix}'
 

--- a/text-generation-webui-3.8/modules/dataset_tool.py
+++ b/text-generation-webui-3.8/modules/dataset_tool.py
@@ -164,9 +164,9 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
             )
         parts.append(
             f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
+            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке, поэтому не делайте по нему выводов. "
             "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
-            "Заключайте анализ в блоки ```python```. "
-            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
+            "Заключайте анализ в блоки ```python```."
         )
         _preload_table(path)
         return "\n".join(parts)
@@ -216,9 +216,9 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                 )
         parts.append(
             f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
+            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке, поэтому не делайте по нему выводов. "
             "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
-            "Заключайте анализ в блоки ```python```. "
-            f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
+            "Заключайте анализ в блоки ```python```."
         )
         _preload_table(path)
         return "\n".join(parts)
@@ -273,9 +273,9 @@ def summarize_table(file_path: str, max_rows: int = 5, cell_limit: int = 80) -> 
                 )
             parts.append(
                 f"Используйте load_table('{path.name}') для загрузки полной таблицы (или get_table_path('{path.name}') для пути). "
+                f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке, поэтому не делайте по нему выводов. "
                 "Всегда проверяйте df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime) перед фильтрацией. "
-                "Заключайте анализ в блоки ```python```. "
-                f"Предпросмотр ограничен {max_rows} строками и {cell_limit} символами в ячейке."
+                "Заключайте анализ в блоки ```python```."
             )
             _preload_table(path)
             return "\n".join(parts)
@@ -294,9 +294,9 @@ def answer_question_with_pandas(question: str, file_path: str | Path) -> str:
     prompt = (
         f"Предпросмотр таблицы `{table_name}`:\n{summary}\n\n"
         f"Вопрос: {question}\n"
-        "Напишите код на pandas, чтобы ответить на вопрос, используя всю таблицу. "
-        f"Получите DataFrame через load_table('{table_name}'). "
-        "Перед фильтрацией посмотрите df.dtypes и при необходимости преобразуйте столбцы (например, pd.to_datetime). "
+        "Ответ должен опираться на полный набор данных, а не на предпросмотр. "
+        f"Получите DataFrame через load_table('{table_name}') (не используйте pd.read_* по пути файла). "
+        "Перед фильтрацией проверьте df.dtypes и при необходимости преобразуйте столбцы, например pd.to_datetime. "
         "Сохраните ответ в переменную `result` и отвечайте на том же языке, что и вопрос."
     )
     return prompt

--- a/text-generation-webui-3.8/modules/python_tool.py
+++ b/text-generation-webui-3.8/modules/python_tool.py
@@ -22,7 +22,16 @@ def execute_python(code: str, out_dir: str | Path | None = None):
     if out_path:
         out_path.mkdir(parents=True, exist_ok=True)
     with contextlib.redirect_stdout(stdout):
-        exec(code, {"plt": plt, "pd": pd, "get_table_path": dataset_tool.get_table_path}, local_vars)
+        exec(
+            code,
+            {
+                "plt": plt,
+                "pd": pd,
+                "get_table_path": dataset_tool.get_table_path,
+                "load_table": dataset_tool.load_table,
+            },
+            local_vars,
+        )
         for num in plt.get_fignums():
             fig = plt.figure(num)
             if out_path:


### PR DESCRIPTION
## Summary
- Ensure images created by the Python tool render in chat by prefixing served paths
- Improve dataset utilities: avoid deprecated `applymap`, support chunked unique counting for large CSVs, resolve registered table names and force stable CSV parsing

## Testing
- `python -m py_compile modules/chat.py modules/dataset_tool.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890a75a5ed88322a839d95eb982dca0